### PR TITLE
修复autocrafter无法开启的bug

### DIFF
--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -277,7 +277,7 @@ minetest.register_node("pipeworks:autocrafter", {
 		update_meta(meta, false)
 	end,
 	on_receive_fields = function(pos, formname, fields, sender)
-		if not fields.channel or (fields.quit and not fields.key_enter_field)
+		if (fields.quit and not fields.key_enter_field)
 				or not pipeworks.may_configure(pos, sender) then
 			return
 		end


### PR DESCRIPTION
问题来自于commit-c39d40e